### PR TITLE
Updating list of domains to match 1678

### DIFF
--- a/config/clusters/callysto/common.values.yaml
+++ b/config/clusters/callysto/common.values.yaml
@@ -101,7 +101,21 @@ jupyterhub:
     config:
       EmailAuthenticatingCILogonOAuthenticator:
         allowed_domains:
-          - "*.edu"
+          - callysto.ca
+          - cybera.ca
+          - wsrd.ca
+          - fmpsd.ab.ca
+          - fmcsd.ab.ca
+          - eips.ca
+          - g.eips.ca
+          - eics.ab.ca
+          - rvschools.ab.ca
+          - cssd.ab.ca
+          - btps.ca
+          - ucalgary.ca
+          - ualberta.ca
+          - spschools.org
+          - "*.ca"
           - 2i2c.org
       CILogonOAuthenticator:
         # We set up admin_users, but *not* allowed users. Those are set up via the extraConfig


### PR DESCRIPTION
This is the list of domains we've identified so far and a wildcard for `*.ca`. For the upcoming workshop we're trying to get a lists of domain, but it's tricky, so having the wildcard might help us avoid delays. As we identify more domains, we could add them and ultimately remove the wildcard.